### PR TITLE
initial resources to support DigitalOcean Kubernetes (DOKS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ $ ./scripts/install-pds.sh
 
 ## Current state
 
-Only tested with minikube. Consists of hard coded values added minimally to get the
-Node app running. The **pds-auth** secret is not part of the chart, it's created
+Tested in:
+- minikube
+- DigitalOcean Kubernetes (DOKS)
+
+Consists of hard coded values added minimally to get the Node app running.
+The **pds-auth** secret is not part of the chart, it's created
 by generating values with:
 
 **secp256k1**:
@@ -43,5 +47,13 @@ All of this is wrapped in the `install-pds.sh` script.
 **BUT IT HAS NOT YET BEEN CONFIRMED OPERATIONAL**
 
 ## TODO:
-- move persistent storage to bucket
-- add example for ingress
+- move persistent storage to bucket (only S3 supported right now AFAIK)
+- add example for terminating TLS with cloud controllers
+
+## Supported cloud ecosystems
+
+TBD
+
+In progress:
+- AWS
+- Digital Ocean

--- a/digitalocean/create-kubernetes.sh
+++ b/digitalocean/create-kubernetes.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+while getopts c:k: args
+do
+    case "${args}" in
+        c) context=${OPTARG};;
+        k) cluster=${OPTARG};;
+    esac
+done
+
+doctl --context "$context" kubernetes cluster create "$cluster"

--- a/digitalocean/delete-kubernetes.sh
+++ b/digitalocean/delete-kubernetes.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+while getopts c:k: args
+do
+    case "${args}" in
+        c) context=${OPTARG};;
+        k) cluster=${OPTARG};;
+    esac
+done
+
+doctl --context "$context" kubernetes cluster delete "$cluster"

--- a/digitalocean/save-kubeconfig.sh
+++ b/digitalocean/save-kubeconfig.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+while getopts c:k: args
+do
+    case "${args}" in
+        c) context=${OPTARG};;
+        k) cluster=${OPTARG};;
+    esac
+done
+
+doctl --context "$context" kubernetes cluster kubeconfig save "$cluster"

--- a/scripts/install-pds.sh
+++ b/scripts/install-pds.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 ##
-## Disclaimer: only tested on MacOS with minikube
+## Disclaimer: only tested on MacOS with:
+## minikube
+## DigitalOcean Kubernetes (DOKS)
 ##
 
 set -e


### PR DESCRIPTION
includes:
- a few simple scripts to create a kubernetes cluster with doctl (Digital Ocean CLI)
- updates README to account for generic PDS chart being deployed (ie the node app runs, but isn't connecting to anything) to Digital Ocean

hope that one day atproto PDS could be made available as a 1-Click for Kubernetes app on Digital Ocean. in which case, would update scripts/docs to run PDS via doctl as a 1-Click app